### PR TITLE
Implementation of IPv6 for Proxy-V2

### DIFF
--- a/rebar.lock
+++ b/rebar.lock
@@ -1,4 +1,0 @@
-[{<<"sync">>,
-  {git,"https://github.com/rustyio/sync.git",
-       {ref,"11df81d196eaab2d84caa3fbe8def5d476ef79d8"}},
-  0}].

--- a/src/tecipe_acceptor_dynamic.erl
+++ b/src/tecipe_acceptor_dynamic.erl
@@ -27,7 +27,6 @@ worker_loop(AcceptorWorker, Handler, Transport, ListeningSock, ListenerRec) ->
     {ok, Sock} = Transport:accept(ListeningSock),
     ok = add_worker(AcceptorWorker),
     unlink(AcceptorWorker),
-
     TecipeSock = tecipe_socket:upgrade(Sock, Transport, ListenerRec),
 
     WorkerPID = self(),
@@ -38,7 +37,7 @@ worker_loop(AcceptorWorker, Handler, Transport, ListeningSock, ListenerRec) ->
 	_ ->
 	    ok
     end,
-
+    
     case Handler of
 	{Module, Function, Args} ->
 	    apply(Module, Function, [Transport, TecipeSock, Args]);

--- a/src/tecipe_listener_sup.erl
+++ b/src/tecipe_listener_sup.erl
@@ -15,7 +15,8 @@ init([Ref, Port, Handler, ListenerRec]) ->
 
     Transport = ListenerRec#tecipe_listener.transport,
     TransportInitOpts = ListenerRec#tecipe_listener.transport_init_opts,
-    {ok, ListeningSock} = Transport:listen(Port, TransportInitOpts),
+    TransportUserOpts = ListenerRec#tecipe_listener.transport_user_opts,
+    {ok, ListeningSock} = Transport:listen(Port, TransportInitOpts ++ TransportUserOpts),
 
     AcceptorChild =
 	case ListenerRec#tecipe_listener.acceptor_type of

--- a/src/tecipe_mock.erl
+++ b/src/tecipe_mock.erl
@@ -1,0 +1,31 @@
+-module(tecipe_mock).
+
+-export([echo_handler/3, run/1]).
+
+-include("tecipe.hrl").
+
+echo_handler(Transport, #tecipe_socket{inet_socket = Sock} = TecipeSock, Args) ->
+    error_logger:info_msg("echo handler socket: ~p~n", [TecipeSock]),
+    receive
+	{tcp, Sock, Data} ->
+	    error_logger:info_msg("echo handler got: ~p~n", [Data]),
+	    Transport:send(TecipeSock, Data),
+	    error_logger:info_msg("echo handler sent: ~p~n", [Data]),
+	    echo_handler(Transport, TecipeSock, Args);
+	{tcp_error, Sock, _Reason} ->
+	    error_logger:info_msg("echo handler got error and closed!~n"),
+	    Transport:close(TecipeSock);
+	{tcp_closed, Sock} ->
+	    error_logger:info_msg("echo handler closed.~n"),
+	    Transport:close(TecipeSock);
+	Unexpected ->
+	    error_logger:info_msg("echo handler got unexpected data and closed: ~p~n", [Unexpected]),
+	    Transport:close(TecipeSock)
+    end.
+
+run(Port) ->
+    IpAddr = tecipe_utils:ipv6_ascii_to_bin("::1"),
+    tecipe:start_listener(mock, Port, {tecipe_mock, echo_handler, []},
+			  [{acceptor, dynamic}, {pool, 10},
+			   {transport, tecipe_tcp}, {monitor, true}, {proxy, v2}],
+			  [{reuseaddr, true}, inet6, {ip, IpAddr}]).

--- a/src/tecipe_proxy.erl
+++ b/src/tecipe_proxy.erl
@@ -90,8 +90,19 @@ do_parse_v2(#tecipe_proxy{proxy_family = inet4} = Proxy,
       source_port = SourcePort,
       dest_port = DestPort};
 
+do_parse_v2(#tecipe_proxy{proxy_family = inet6} = Proxy,
+	    <<SA1:16, SA2:16, SA3:16, SA4:16, SA5:16, SA6:16, SA7:16, SA8:16,
+	      DA1:16, DA2:16, DA3:16, DA4:16, DA5:16, DA6:16, DA7:16, DA8:16,
+	      SrcPort:16,
+	      DestPort:16, _/binary>>) ->
+    Proxy#tecipe_proxy{
+      source_address = SrcPort,
+      dest_address = DestPort,
+      source_port = {SA1, SA2, SA3, SA4, SA5, SA6, SA7, SA8},
+      dest_port = {DA1, DA2, DA3, DA4, DA5, DA6, DA7, DA8}};
+
 do_parse_v2(Proxy, _) ->
-    %% @TODO: implement inet6 and unix sockets
+    %% @TODO: implement unix sockets
     Proxy#tecipe_proxy{
       source_address = unsupported,
       dest_address = unsupported,

--- a/src/tecipe_socket.erl
+++ b/src/tecipe_socket.erl
@@ -17,7 +17,5 @@ upgrade(Sock, Transport, ListenerRec) ->
 -spec apply_opts(tecipe_socket(),
 		 tecipe_listener_transport(),
 		 tecipe_listener()) -> ok.
-apply_opts(Sock, Transport, #tecipe_listener{transport_user_opts = UserOpts,
-					     transport_default_opts = DefaultOpts}) ->
-    %% @NOTE: user options has precedence over default options, so they come first in list
-    Transport:setopts(Sock, UserOpts ++ DefaultOpts).
+apply_opts(Sock, Transport, #tecipe_listener{transport_default_opts = DefaultOpts}) ->
+    Transport:setopts(Sock, DefaultOpts).

--- a/src/tecipe_utils.erl
+++ b/src/tecipe_utils.erl
@@ -1,30 +1,24 @@
 -module(tecipe_utils).
 
--export([echo_handler/3, test/1]).
+-export([ipv4_ascii_to_bin/1, ipv4_bin_to_ascii/1]).
+-export([ipv6_ascii_to_bin/1, ipv6_bin_to_ascii/1]).
 
--include("tecipe.hrl").
+-spec ipv4_ascii_to_bin(string()) -> inet:ip4_address().
+ipv4_ascii_to_bin(IPv4Ascii) ->
+    {ok, IPv4Tuple} = inet_parse:ipv4strict_address(IPv4Ascii),
+    IPv4Tuple.
 
-echo_handler(Transport, #tecipe_socket{inet_socket = Sock} = TecipeSock, Args) ->
-    error_logger:info_msg("echo handler socket: ~p~n", [TecipeSock]),
-    receive
-	{tcp, Sock, Data} ->
-	    error_logger:info_msg("echo handler got: ~p~n", [Data]),
-	    Transport:send(TecipeSock, Data),
-	    error_logger:info_msg("echo handler sent: ~p~n", [Data]),
-	    echo_handler(Transport, TecipeSock, Args);
-	{tcp_error, Sock, _Reason} ->
-	    error_logger:info_msg("echo handler got error and closed!~n"),
-	    Transport:close(TecipeSock);
-	{tcp_closed, Sock} ->
-	    error_logger:info_msg("echo handler closed.~n"),
-	    Transport:close(TecipeSock);
-	Unexpected ->
-	    error_logger:info_msg("echo handler got unexpected data and closed: ~p~n", [Unexpected]),
-	    Transport:close(TecipeSock)
-    end.
+-spec ipv4_bin_to_ascii(inet:ip4_address()) -> string().
+ipv4_bin_to_ascii(IPv4Tuple) ->
+    IPv4Ascii = inet_parse:ntoa(IPv4Tuple),
+    IPv4Ascii.
 
-test(Port) ->
-    tecipe:start_listener(test, Port, {tecipe_utils, echo_handler, []},
-			  [{acceptor, dynamic}, {pool, 10},
-			   {transport, tecipe_tcp}, {monitor, true}, {proxy, v2}],
-			  [{reuseaddr, true}]).
+-spec ipv6_ascii_to_bin(string()) -> inet:ip6_address().
+ipv6_ascii_to_bin(IPv6Ascii) ->
+    {ok, IPv6Tuple} = inet_parse:ipv6strict_address(IPv6Ascii),
+    IPv6Tuple.
+
+-spec ipv6_bin_to_ascii(inet:ip6_address()) -> string().
+ipv6_bin_to_ascii(IPv6Tuple) ->
+    IPv6Ascii = inet_parse:ntoa(IPv6Tuple),
+    IPv6Ascii.


### PR DESCRIPTION
In this branch I implement IPv6 for Proxy-V2 Protocol, Furthermore I merge the user options with default options in tecipe_listener_sup file.